### PR TITLE
## Release Notes for **GHRD for Agilex 7 FPGA 26.1**

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,7 @@ $(strip $(2))-package-design: | $(strip $(5))
 
 .PHONY: $(strip $(2))-build
 $(strip $(2))-build: | $(strip $(1))/output_files
-	cd $(strip $(1)) && quartus_syn $(strip $(3))
-	cd $(strip $(1)) && quartus_fit $(strip $(3))
-	cd $(strip $(1)) && quartus_asm $(strip $(3))
-	cd $(strip $(1)) && quartus_sta $(strip $(3)) --mode=finalize
+	cd $(strip $(1)) && quartus_sh --flow compile $(strip $(3)) -c $(strip $(3))
 
 .PHONY: $(strip $(2))-sw-build
 $(strip $(2))-sw-build:
@@ -122,12 +119,15 @@ endef
 # Create the recipes by calling create_ghrd_target on each design
 # Agilex 7
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agi027fc-si-devkit-oobe-baseline, ghrd_agib027r31b1e1vb, generate-agi027fc-si-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
+$(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agi027fd-si-devkit-oobe-baseline, ghrd_agib027r31b1e1vc, generate-agi027fd-si-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-oobe-baseline, ghrd_agfb014r24b2e2v, generate-agf014eb-si-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-nand-baseline, ghrd_agfb014r24b2e2v, generate-agf014eb-si-devkit-nand-baseline, $(INSTALL_ROOT)/designs))
+$(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-oobe-sgmii, ghrd_agfb014r24b2e2v, generate-agf014eb-si-devkit-oobe-sgmii, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-oobe-pr, ghrd_agfb014r24b2e2v, generate-agf014eb-si-devkit-oobe-pr, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agm039fes-soc-devkit-oobe-baseline, ghrd_agmf039r47a1e2vr0, generate-agm039fes-soc-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agf023fa-soc-devkit-oobe-baseline, ghrd_agfd023r24c2e1vc, generate-agf023fa-soc-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
 $(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agm039ea-soc-devkit-oobe-baseline, ghrd_agmf039r47a1e1vc, generate-agm039ea-soc-devkit-oobe-baseline, $(INSTALL_ROOT)/designs))
+$(eval $(call create_legacy_ghrd_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-emmc-baseline, ghrd_agfb014r24b2e2v, generate-agf014eb-si-devkit-emmc-baseline, $(INSTALL_ROOT)/designs))
 
 ###############################################################################
 #                          UTILITY TARGETS
@@ -221,14 +221,16 @@ endef
 # Create the HPS Debug SOF
 # must first call create_fsbl_sw_target
 # Agilex 7
-$(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf027f1es-soc-devkit-oobe-baseline, ghrd_agfb027r24c2e2v, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agi027fc-si-devkit-oobe-baseline, ghrd_agib027r31b1e1vb, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
+$(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agi027fd-si-devkit-oobe-baseline, ghrd_agib027r31b1e1vc, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-oobe-baseline, ghrd_agfb014r24b2e2v, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-nand-baseline, ghrd_agfb014r24b2e2v, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
+$(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-oobe-sgmii, ghrd_agfb014r24b2e2v, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-oobe-pr, ghrd_agfb014r24b2e2v, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agm039fes-soc-devkit-oobe-baseline, ghrd_agmf039r47a1e2vr0, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf023fa-soc-devkit-oobe-baseline, ghrd_agfd023r24c2e1vc, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 $(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agm039ea-soc-devkit-oobe-baseline, ghrd_agmf039r47a1e1vc, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
+$(eval $(call create_fsbl_insertion_target, agilex_soc_devkit_ghrd, agf014eb-si-devkit-emmc-baseline, ghrd_agfb014r24b2e2v, $(AGILEX_FSBL_IHEX), hps_debug, $(INSTALL_ROOT)/designs))
 
 ###############################################################################
 #                           PR Persona RBF

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ This is applicable to all designs.
   - Partial Reconfiguration
 
 ## Dependency
-* Altera Quartus Prime 25.3.1
+* Altera Quartus Prime 26.1
 * Supported Board
-  - Intel Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
+  - Altera Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
   - Altera Agilex F-Series FPGA Development Kit
-  - Intel Agilex 7 FPGA I-Series Transceiver-SoC Development Kit
-  - Intel Agilex 7 FPGA M-Series Development Kit - HBM2e Edition
+  - Altera Agilex 7 FPGA I-Series Transceiver-SoC Development Kit
+  - Altera Agilex 7 FPGA M-Series Development Kit - HBM2e Edition
 
 ## Tested Platform for the GHRD Make flow
 * SUSE Linux Enterprise Server 15 SP4
 
 ## Supported Designs
-### Platform: Intel Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
+### Platform: Altera Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
 #### Baseline
 This design boots from SD/MMC.
 HPS EMIF ECC is enabled by default.
@@ -57,16 +57,36 @@ HPS EMIF ECC is enabled by default.
 ```bash
 make agf014eb-si-devkit-oobe-pr-all
 ```
+#### EMMC
+This design boots from EMMC.
+HPS EMIF ECC is enabled by default.
 
-### Platform: Intel Agilex 7 FPGA I-Series Transceiver-SoC Development Kit
+```bash
+make agf014eb-si-devkit-emmc-baseline-all
+```
+#### HPS Serial Gigabit Media Independent Interface (SGMII)
+This design boots from SD/MMC and enabled SGMII with HPS EMAC and Triple-Speed Ethernet Intel FPGA IP (PHY).
+HPS EMIF ECC is enabled by default.
+
+```bash
+make agf014eb-si-devkit-oobe-sgmii-all
+```
+
+### Platform: Altera Agilex 7 FPGA I-Series Transceiver-SoC Development Kit
 Note: There are several versions for this Development Kit. They can be identified with the Ordering Code in brackets.
 #### Baseline (DK-SI-AGI027FC)
 This design boots from SD/MMC.
 ```bash
 make agi027fc-si-devkit-oobe-baseline-all
 ```
+#### Baseline (DK-SI-AGI027FD)
+This design boots from SD/MMC.
+**Note: This design successfully meets Quartus compilation and timing requirements, but has not yet been validated on hardware.**
+```bash
+make agi027fd-si-devkit-oobe-baseline-all
+```
 
-### Platform: Intel Agilex 7 FPGA M-Series Development Kit - HBM2e Edition
+### Platform: Altera Agilex 7 FPGA M-Series Development Kit - HBM2e Edition
 #### Baseline (DK-DEV-AGM039FES)
 This design boots from SD/MMC.
 It also intantiates External Memory Interfaces IP for Hard Processor System to access the DDR5 memory.
@@ -86,7 +106,7 @@ make agm039ea-soc-devkit-oobe-baseline-all
 ```
 
 
-### Platform: Intel Agilex 7 FPGA F-Series Development Kit - 2F Tile Crypto
+### Platform: Altera Agilex 7 FPGA F-Series Development Kit - 2F Tile Crypto
 #### Baseline (DK-DEV-AGF023FA)
 This design boots from SD/MMC.
 HPS EMIF ECC is enabled by default.

--- a/agilex_soc_devkit_ghrd/Makefile
+++ b/agilex_soc_devkit_ghrd/Makefile
@@ -955,6 +955,9 @@ generate-agf027f1es-soc-devkit-oobe-baseline:
 generate-agi027fc-si-devkit-oobe-baseline:
 	make generate_from_tcl_internal BOARD_TYPE=devkit_fm87 BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1 FPGA_SGPIO_EN=1
 
+generate-agi027fd-si-devkit-oobe-baseline:
+	make generate_from_tcl_internal BOARD_TYPE=devkit_fm87 QUARTUS_DEVICE=AGIB027R31B1E1VC BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1 FPGA_SGPIO_EN=1
+
 generate-agi027fa-si-devkit-oobe-baseline:
 	make generate_from_tcl_internal BOARD_TYPE=devkit_fm87 BOARD_PWRMGT=linear QUARTUS_DEVICE=AGIB027R31B1E1V ENABLE_HPS_EMIF_ECC=1 FPGA_SGPIO_EN=1
 
@@ -966,6 +969,12 @@ generate-agf014eb-si-devkit-oobe-baseline:
 
 generate-agf014eb-si-devkit-nand-baseline:
 	make generate_from_tcl_internal BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear DAUGHTER_CARD=devkit_dc_nand
+
+generate-agf014eb-si-devkit-emmc-baseline:
+	make generate_from_tcl_internal BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear DAUGHTER_CARD=devkit_dc_emmc
+
+generate-agf014eb-si-devkit-oobe-sgmii:
+	make generate_from_tcl_internal BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear HPS_ENABLE_SGMII=1
 
 generate-agf014eb-si-devkit-oobe-pr:
 	make generate_from_tcl_internal BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1 ENABLE_PARTIAL_RECONFIGURATION=1
@@ -984,11 +993,11 @@ generate-agf023fa-soc-devkit-oobe-baseline:
 
 generate-agm039ea-soc-devkit-oobe-baseline:
 	make generate_from_tcl_internal QUARTUS_DEVICE=AGMF039R47A1E1VC BOARD_TYPE=devkit_fp82 CONFIG_SCHEME="AVST\ X8" BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=0 ENABLE_WATCHDOG_RST=0 OCM_DATAWIDTH=32 HBM_EN=1 HPS_F2S_IRQ_EN=0 HPS_STM_EN=0 HPS_EMIF_EN=0
-	
+
 generate-fpga_first_revb_linear:
 	make generate_from_tcl_internal BOOTS_FIRST=fpga BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1
-	
-generate-fpga_first_pr_linear: 
+
+generate-fpga_first_pr_linear:
 	make generate_from_tcl_internal BOOTS_FIRST=fpga BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1 ENABLE_PARTIAL_RECONFIGURATION=1
 
 ################################################

--- a/agilex_soc_devkit_ghrd/README.md
+++ b/agilex_soc_devkit_ghrd/README.md
@@ -10,7 +10,7 @@ The GHRD is part of the Golden System Reference Design (GSRD), which provides a 
    - $ `make sof` or $ `make all`
 
 ## Supported Designs
-### Platform: Intel Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
+### Platform: Altera Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
 There are **4 LED outputs**, **4 DIP switch inputs** and **4 push-button inputs** on the Development Kit, which are connected fpga pin.
 #### Baseline
 This design boots from SD/MMC.
@@ -30,8 +30,22 @@ HPS EMIF ECC is enabled by default.
 ```bash
 make generate-agf014eb-si-devkit-oobe-pr
 ```
+#### EMMC
+This design boots from EMMC.
+HPS EMIF ECC is enabled by default.
 
-### Platform: Intel Agilex 7 FPGA I-Series Transceiver-SoC Development Kit
+```bash
+make generate-agf014eb-si-devkit-emmc-baseline
+```
+#### HPS Serial Gigabit Media Independent Interface (SGMII)
+This design boots from SD/MMC and enabled SGMII with HPS EMAC and Triple-Speed Ethernet Intel FPGA IP (PHY).
+HPS EMIF ECC is enabled by default.
+
+```bash
+make generate-agf014eb-si-devkit-oobe-sgmii
+```
+
+### Platform: Altera Agilex 7 FPGA I-Series Transceiver-SoC Development Kit
 There are **8 LED outputs**, **8 DIP switch inputs** and **2 push-button inputs** on the Development Kit, which are connected fpga pin.<br>
 Note: There are several versions for this Development Kit. They can be identified with the Ordering Code in brackets.
 #### Baseline (DK-SI-AGI027FC)
@@ -40,8 +54,15 @@ HPS EMIF ECC is enabled by default.
 ```bash
 make generate-agi027fc-si-devkit-oobe-baseline
 ```
+#### Baseline (DK-SI-AGI027FD)
+This design boots from SD/MMC.
+HPS EMIF ECC is enabled by default.
+**Note: This design successfully meets Quartus compilation and timing requirements, but has not yet been validated on hardware.**
+```bash
+make generate-agi027fd-si-devkit-oobe-baseline
+```
 
-### Platform: Intel Agilex 7 FPGA M-Series Development Kit - HBM2e Edition
+### Platform: Altera Agilex 7 FPGA M-Series Development Kit - HBM2e Edition
 There are **4 LED outputs** on the Development Kit, which are connected fpga pin.
 #### Baseline (DK-DEV-AGM039FES)
 This design boots from SD/MMC.
@@ -61,7 +82,7 @@ HBM ECC is **enabled** for this design.
 make agm039ea-soc-devkit-oobe-baseline-all
 ```
 
-### Platform: Intel Agilex 7 FPGA F-Series Development Kit - 2F Tile Crypto
+### Platform: Altera Agilex 7 FPGA F-Series Development Kit - 2F Tile Crypto
 There are **4 LED outputs** on the Development Kit, which are connected fpga pin.
 #### Baseline (DK-DEV-AGF023FA)
 This design boots from SD/MMC.
@@ -73,7 +94,7 @@ make generate-agf023fa-soc-devkit-oobe-baseline
 ## GHRD Overview
 
 ### Hard Processor System (HPS)
-The GHRD HPS configuration matches the board schematic. Refer to [Agilex 7 Hard Processor System Technical Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683567/current) and [Intel Agilex 7 Hard Processor System Component Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683581/current) for more information on HPS configuration.
+The GHRD HPS configuration matches the board schematic. Refer to [Agilex 7 Hard Processor System Technical Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683567/current) and [Agilex 7 Hard Processor System Component Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683581/current) for more information on HPS configuration.
 
 ### HPS External Memory Interfaces (EMIF)
 The GHRD HPS EMIF configuration matches the board schematic. Refer to
@@ -82,7 +103,7 @@ The GHRD HPS EMIF configuration matches the board schematic. Refer to
 ### HPS-to-FPGA Address Map for all designs
 The MPU region provide windows of 4 GB into the FPGA slave address space. The lower 1.5 GB of this space is mapped to two separate addresses - firstly from 0x8000_0000 to 0xDFFF_FFFF and secondly from 0x20_0000_0000 to 0x20_5FFF_FFFF. The following table lists the offset of each peripheral from the HPS-to-FPGA bridge in the FPGA portion of the SoC.
 
-Refer to [Intel Agilex 7 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/agilex7/hps.html) for details.
+Refer to [Agilex 7 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/agilex7/hps.html) for details.
 
 | Peripheral | Address Offset | Size (bytes) | Attribute |
 | :-- | :-- | :-- | :-- |

--- a/agilex_soc_devkit_ghrd/board/board_DK-SI-AGF014E_pin_assignment_table.tcl
+++ b/agilex_soc_devkit_ghrd/board/board_DK-SI-AGF014E_pin_assignment_table.tcl
@@ -147,11 +147,8 @@ set fpga_gpio0_pin "V45"
 
 
 ## SGMII Related IOs
-if {$board_pwrmgt == "linear"} {
-set enet_refclk_pin "CG24"
-} else {
 set enet_refclk_pin "CN22"
-}
+
 set emac_sgmii_rxp_pin "CH21"
 set emac_sgmii_rxn_pin "CF21"
 set emac_sgmii_txp_pin "CG22"

--- a/agilex_soc_devkit_ghrd/board/board_devkit_fp82_config.tcl
+++ b/agilex_soc_devkit_ghrd/board/board_devkit_fp82_config.tcl
@@ -27,28 +27,27 @@ set hps_emif_bank_gp_default_width 1
 
 # Quartus settings for SDMIOs
 proc config_sdmio {} {
-    set_global_assignment -name USE_HPS_COLD_RESET SDM_IO9
+    set_global_assignment -name USE_HPS_COLD_RESET SDM_IO12
     set_global_assignment -name USE_CONF_DONE SDM_IO5
-} 
+}
 
 # Quartus settings for Power Management
 proc config_pwrmgt {} {
     global board_pwrmgt
     if {$board_pwrmgt == "linear"} {
         # Linear tech
-        set_global_assignment -name INI_VARS "ASM_ENABLE_ADVANCED_DEVICES=ON;"
         set_global_assignment -name VID_OPERATION_MODE "PMBUS MASTER"
         set_global_assignment -name USE_PWRMGT_SCL SDM_IO0
         set_global_assignment -name USE_PWRMGT_SDA SDM_IO16
-		set_global_assignment -name PWRMGT_BUS_SPEED_MODE "400 KHZ"
+        set_global_assignment -name PWRMGT_BUS_SPEED_MODE "400 KHZ"
         set_global_assignment -name PWRMGT_SLAVE_DEVICE_TYPE LTC3888
-		set_global_assignment -name NUMBER_OF_SLAVE_DEVICE 1
+        set_global_assignment -name NUMBER_OF_SLAVE_DEVICE 1
         set_global_assignment -name PWRMGT_SLAVE_DEVICE0_ADDRESS 55
         set_global_assignment -name PWRMGT_VOLTAGE_OUTPUT_FORMAT "LINEAR FORMAT"
         set_global_assignment -name PWRMGT_LINEAR_FORMAT_N "-12"
         set_global_assignment -name PWRMGT_TRANSLATED_VOLTAGE_VALUE_UNIT VOLTS
-		set_global_assignment -name PWRMGT_PAGE_COMMAND_ENABLE ON
-		set_global_assignment -name PWRMGT_PAGE_COMMAND_PAYLOAD 0
-
-    } 
+        set_global_assignment -name PWRMGT_PAGE_COMMAND_ENABLE ON
+        set_global_assignment -name PWRMGT_PAGE_COMMAND_PAYLOAD 0
+        set_global_assignment -name USE_NCATTRIP SDM_IO7
+    }
 }

--- a/agilex_soc_devkit_ghrd/create_ghrd_quartus.tcl
+++ b/agilex_soc_devkit_ghrd/create_ghrd_quartus.tcl
@@ -170,7 +170,21 @@ set_global_assignment -name STRATIX_JTAG_USER_CODE 3
 set_global_assignment -name USE_CHECKSUM_AS_USERCODE OFF
 } else {
 if {$board == "devkit_fm86" | $board == "devkit_fm87" | $board == "DK-SI-AGF014E" | $board == "devkit_fp82" | $board == "DK-DEV-AGF023FA" && $daughter_card == "devkit_dc_oobe"} {
+
+if {$board == "DK-SI-AGF014E" && $hps_sgmii_en == 1} {
+set_global_assignment -name STRATIX_JTAG_USER_CODE "B"
+set_instance_assignment -name INPUT_TERMINATION OFF -to enet_refclk
+set_instance_assignment -name INPUT_TERMINATION OFF -to emac1_sgmii_rxp
+set_instance_assignment -name INPUT_TERMINATION OFF -to emac1_mdio
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 40 OHM WITHOUT CALIBRATION" -to emac1_mdio
+set_instance_assignment -name SLEW_RATE 2 -to emac1_mdio
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 40 OHM WITHOUT CALIBRATION" -to emac1_mdc
+set_instance_assignment -name SLEW_RATE 2 -to emac1_mdc
+set_instance_assignment -name OUTPUT_TERMINATION "SERIES 40 OHM WITHOUT CALIBRATION" -to emac1_phy_rst_n
+set_instance_assignment -name SLEW_RATE 2 -to emac1_phy_rst_n
+} else {
 set_global_assignment -name STRATIX_JTAG_USER_CODE 4
+}
 set_global_assignment -name USE_CHECKSUM_AS_USERCODE OFF
 } elseif {$board == "DK-SI-AGF014E" && $daughter_card == "devkit_dc_nand"} {
 set_global_assignment -name STRATIX_JTAG_USER_CODE 1
@@ -231,6 +245,7 @@ if {$hbm_en == 1} {
 	set_instance_assignment -name NOC_GROUP NOC_GROUP_0 -to soc_inst|agilex_hps|intel_agilex_hps_inst|iniu_0|initiator_inst_0 -entity $top_name
 	set_location_assignment PIN_AP33 -to hbm_core_pll_refclk_clk
 	set_instance_assignment -name IO_STANDARD "1.2V TRUE DIFFERENTIAL SIGNALING" -to hbm_core_pll_refclk_clk -entity $top_name
+	set_instance_assignment -name INPUT_TERMINATION OFF -to hbm_core_pll_refclk_clk
 	set_location_assignment PIN_AR36 -to uibpll_refclk_clk
 	set_instance_assignment -name IO_STANDARD "1.2V TRUE DIFFERENTIAL SIGNALING" -to uibpll_refclk_clk -entity $top_name
 	set_location_assignment PIN_E38 -to hbm_only_reset_reset
@@ -310,7 +325,7 @@ if {$hbm_en == 1} {
 		set_location_assignment PIN_FC22 -to noc_clock_ctrl_pll_lock_o_pll_lock_o
 		set_instance_assignment -name IO_STANDARD "1.2-V" -to noc_clock_ctrl_pll_lock_o_pll_lock_o
 		set_instance_assignment -name SLEW_RATE 1 -to noc_clock_ctrl_pll_lock_o_pll_lock_o
-
+		set_instance_assignment -name OUTPUT_TERMINATION "SERIES 40 OHM WITHOUT CALIBRATION" -to noc_clock_ctrl_pll_lock_o_pll_lock_o
 }
 }
 
@@ -588,16 +603,18 @@ set_instance_assignment -name OUTPUT_TERMINATION "SERIES 40 OHM WITHOUT CALIBRAT
 }
 
 if {$board == "devkit_fp82" && $hps_emif_en == 1} {
-set_instance_assignment -name SLEW_RATE 0 -to fpga_clk_100[0]
+set_instance_assignment -name SLEW_RATE 0 -to fpga_clk_100
 set_instance_assignment -name SLEW_RATE 0 -to emif_hps_noc_refclk_clk
 set_instance_assignment -name IO_STANDARD "1.8-V" -to emif_hps_noc_refclk_clk
-set_instance_assignment -name SLEW_RATE 0 -to fpga_reset_n[0]
+set_instance_assignment -name SLEW_RATE 0 -to fpga_reset_n
 set_instance_assignment -name SLEW_RATE 0 -to emif_hps_oct_oct_rzqin
 set_instance_assignment -name IO_STANDARD "1.1-V" -to emif_hps_oct_oct_rzqin
 set_instance_assignment -name IO_STANDARD "1.1-V" -to emif_hps_noc_pll_lock_o_pll_lock_o
 set_instance_assignment -name SLEW_RATE 0 -to emif_hps_noc_pll_lock_o_pll_lock_o
 set_instance_assignment -name OUTPUT_TERMINATION "SERIES 40 OHM WITHOUT CALIBRATION" -to emif_hps_noc_pll_lock_o_pll_lock_o
 }
+
+set_instance_assignment -name INPUT_TERMINATION OFF -to fpga_clk_100
 
 # Convert timing failures to errors
 set_global_assignment -name PROMOTE_WARNING_TO_ERROR 332148

--- a/agilex_soc_devkit_ghrd/sgmii_timing.sdc
+++ b/agilex_soc_devkit_ghrd/sgmii_timing.sdc
@@ -14,3 +14,8 @@ set_false_path -from * -to [get_keepers {*|sgmii_debug_status_pio|altera_avalon_
 
 # False path to COL for duplex SGMII Mode
 set_false_path -from [get_keepers -no_duplicates {soc_inst|*|altera_eth_tse_inst|i_tse_pcs_0|altera_tse_top_1000_base_x_inst|U_SGMII|U_COL|state}] -to [get_keepers -no_duplicates {soc_inst|agilex_hps|*|s2f_module~soc_hps_wrapper/s0_b_28__vio_lab_core_periphery__clk[*].reg}]
+
+# The PCS clock (external) and hps_emac1_gtx_clk (HPS generated clock) are logically exclusive to each other through a clock multiplexer
+set_clock_groups -logically_exclusive -group [get_clocks {PCS_CLOCK}] -group [get_clocks {hps_emac1_gtx_clk}]
+
+set_output_delay -clock MAIN_CLOCK 5 [get_ports {emac1_phy_rst_n}]

--- a/agilex_soc_devkit_ghrd/top_level_sdc_template.sdc.terp
+++ b/agilex_soc_devkit_ghrd/top_level_sdc_template.sdc.terp
@@ -12,12 +12,12 @@
 set_time_format -unit ns -decimal_places 3
 
 # 100MHz board input clock, 133.3333MHz for EMIF refclk
-create_clock -name MAIN_CLOCK -period 10 [get_ports fpga_clk_100[0]]
+create_clock -name MAIN_CLOCK -period 10 [get_ports fpga_clk_100]
 @@if {$board == "devkit_fp82" && $hbm_en != 1} {
-create_clock -name EMIF_REF_CLOCK -period ${hps_emif_ref_clk_freq_mhz}MHz [get_ports emif_hps_ref_clk_clk] 
+create_clock -name EMIF_REF_CLOCK -period ${hps_emif_ref_clk_freq_mhz}MHz [get_ports emif_hps_ref_clk_clk]
 @@} elseif {$board == "devkit_fp82" && $hbm_en == 1} {
 @@if {$hps_emif_en == 1} {
-create_clock -name EMIF_REF_CLOCK -period ${hps_emif_ref_clk_freq_mhz}MHz [get_ports emif_hps_ref_clk_clk] 
+create_clock -name EMIF_REF_CLOCK -period ${hps_emif_ref_clk_freq_mhz}MHz [get_ports emif_hps_ref_clk_clk]
 @@}
 create_clock -name corepll_clk -period 10 [get_ports hbm_core_pll_refclk_clk]
 create_clock -name uibpll_refclk -period 10 [get_ports uibpll_refclk_clk]
@@ -88,7 +88,6 @@ set_output_delay -clock MAIN_CLOCK 5 [get_ports {fpga_led_pio[3]}]
 @@  for {set m $hps_sgmii_emac_start_node} {$m<=$hps_sgmii_emac_end_node} {incr m} {
 set_max_skew -to [get_ports "emac${m}_mdc"] 2
 set_max_skew -to [get_ports "emac${m}_mdio"] 2
-set_false_path -from * -to [ get_ports emac${m}_phy_rst_n ]
-set_false_path -from [get_ports {emac${m}_phy_irq}] -to *
+set_false_path -from * -to [get_ports emac${m}_phy_rst_n]
 @@  }
 @@}

--- a/agilex_soc_devkit_ghrd/top_level_template.v.terp
+++ b/agilex_soc_devkit_ghrd/top_level_template.v.terp
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: Copyright (C) 2025 Altera Corporation
 //
 //****************************************************************************
-// This is a generated system top level RTL file. 
+// This is a generated system top level RTL file.
 
 @@if {$hps_emif_ecc_en == 1} {
 @@   incr hps_emif_width 8
@@ -37,7 +37,7 @@ input    wire          refclk_bti,
 @@}
 // Clock and Reset
 @@if {$h2f_user0_clk_en == 0} {
-input    wire [1-1:0]  fpga_clk_100,
+input    wire          fpga_clk_100,
 @@}
 
 @@if {$fpga_sgpio_en == 1} {
@@ -61,10 +61,10 @@ input    wire [$fpga_button_pio_width-1:0]  fpga_button_pio,
 @@if {$fpga_pcie == 1} {
 input    wire           pcie_hip_refclk0_clk,
 input    wire           pcie_hip_refclk1_clk,
-//input    wire [$pcie_count-1:0]      pcie_hip_serial_rx_in,  
+//input    wire [$pcie_count-1:0]      pcie_hip_serial_rx_in,
 //output   wire [$pcie_count-1:0]      pcie_hip_serial_tx_out,
-input    wire [16-1:0]      pcie_hip_serial_rx_p_in,  
-input    wire [16-1:0]      pcie_hip_serial_rx_n_in,  
+input    wire [16-1:0]      pcie_hip_serial_rx_p_in,
+input    wire [16-1:0]      pcie_hip_serial_rx_n_in,
 output   wire [16-1:0]      pcie_hip_serial_tx_p_out,
 output   wire [16-1:0]      pcie_hip_serial_tx_n_out,
 input    wire           pcie_hip_npor_pin_perst,
@@ -162,105 +162,105 @@ output   wire        hps_jtag_tdo,
 input    wire        hps_jtag_tdi,
 @@}
 @@if {$hps_sdmmc4b_q1_en == 1 || $hps_sdmmc8b_q1_en == 1 || $hps_sdmmc4b_q4_en == 1 || $hps_sdmmc8b_q4_en == 1} {
-output   wire        hps_sdmmc_CCLK, 
-inout    wire        hps_sdmmc_CMD,          
-inout    wire        hps_sdmmc_D0,          
-inout    wire        hps_sdmmc_D1,          
-inout    wire        hps_sdmmc_D2,        
-inout    wire        hps_sdmmc_D3,        
+output   wire        hps_sdmmc_CCLK,
+inout    wire        hps_sdmmc_CMD,
+inout    wire        hps_sdmmc_D0,
+inout    wire        hps_sdmmc_D1,
+inout    wire        hps_sdmmc_D2,
+inout    wire        hps_sdmmc_D3,
 @@}
 @@if {$hps_sdmmc8b_q1_en == 1 || $hps_sdmmc8b_q4_en == 1} {
-inout    wire        hps_sdmmc_D4,          
-inout    wire        hps_sdmmc_D5,          
-inout    wire        hps_sdmmc_D6,        
-inout    wire        hps_sdmmc_D7,  
+inout    wire        hps_sdmmc_D4,
+inout    wire        hps_sdmmc_D5,
+inout    wire        hps_sdmmc_D6,
+inout    wire        hps_sdmmc_D7,
 @@}
 @@if {$hps_usb0_en == 1} {
-inout    wire        hps_usb0_DATA0,         
-inout    wire        hps_usb0_DATA1,      
-inout    wire        hps_usb0_DATA2,        
-inout    wire        hps_usb0_DATA3,       
-inout    wire        hps_usb0_DATA4,        
-inout    wire        hps_usb0_DATA5,      
-inout    wire        hps_usb0_DATA6,      
-inout    wire        hps_usb0_DATA7,         
-input    wire        hps_usb0_CLK,         
-output   wire        hps_usb0_STP,       
-input    wire        hps_usb0_DIR,        
-input    wire        hps_usb0_NXT, 
+inout    wire        hps_usb0_DATA0,
+inout    wire        hps_usb0_DATA1,
+inout    wire        hps_usb0_DATA2,
+inout    wire        hps_usb0_DATA3,
+inout    wire        hps_usb0_DATA4,
+inout    wire        hps_usb0_DATA5,
+inout    wire        hps_usb0_DATA6,
+inout    wire        hps_usb0_DATA7,
+input    wire        hps_usb0_CLK,
+output   wire        hps_usb0_STP,
+input    wire        hps_usb0_DIR,
+input    wire        hps_usb0_NXT,
 @@}
 @@if {$hps_usb1_en == 1} {
-inout    wire        hps_usb1_DATA0,         
-inout    wire        hps_usb1_DATA1,      
-inout    wire        hps_usb1_DATA2,        
-inout    wire        hps_usb1_DATA3,       
-inout    wire        hps_usb1_DATA4,        
-inout    wire        hps_usb1_DATA5,      
-inout    wire        hps_usb1_DATA6,      
-inout    wire        hps_usb1_DATA7,         
-input    wire        hps_usb1_CLK,         
-output   wire        hps_usb1_STP,       
-input    wire        hps_usb1_DIR,        
-input    wire        hps_usb1_NXT, 
+inout    wire        hps_usb1_DATA0,
+inout    wire        hps_usb1_DATA1,
+inout    wire        hps_usb1_DATA2,
+inout    wire        hps_usb1_DATA3,
+inout    wire        hps_usb1_DATA4,
+inout    wire        hps_usb1_DATA5,
+inout    wire        hps_usb1_DATA6,
+inout    wire        hps_usb1_DATA7,
+input    wire        hps_usb1_CLK,
+output   wire        hps_usb1_STP,
+input    wire        hps_usb1_DIR,
+input    wire        hps_usb1_NXT,
 @@}
 @@if {$hps_emac0_rmii_en == 1 || $hps_emac0_rgmii_en == 1} {
-output   wire        hps_emac0_TX_CLK,       //TODO: may need to change RMII TX CLK to be input instead, check
-input    wire        hps_emac0_RX_CLK,      
+output   wire        hps_emac0_TX_CLK,
+input    wire        hps_emac0_RX_CLK,
 output   wire        hps_emac0_TX_CTL,
-input    wire        hps_emac0_RX_CTL,      
-output   wire        hps_emac0_TXD0,       
+input    wire        hps_emac0_RX_CTL,
+output   wire        hps_emac0_TXD0,
 output   wire        hps_emac0_TXD1,
-input    wire        hps_emac0_RXD0,     
-input    wire        hps_emac0_RXD1,                
+input    wire        hps_emac0_RXD0,
+input    wire        hps_emac0_RXD1,
 @@}
 @@if {$hps_emac0_rgmii_en == 1} {
-output   wire        hps_emac0_TXD2,        
+output   wire        hps_emac0_TXD2,
 output   wire        hps_emac0_TXD3,
-input    wire        hps_emac0_RXD2,        
-input    wire        hps_emac0_RXD3, 
+input    wire        hps_emac0_RXD2,
+input    wire        hps_emac0_RXD3,
 @@}
 @@if {$hps_mdio0_q1_en == 1 || $hps_mdio0_q3_en == 1 || $hps_mdio0_q4_en == 1} {
-inout    wire        hps_emac0_MDIO,         
+inout    wire        hps_emac0_MDIO,
 output   wire        hps_emac0_MDC,
 @@}
 @@if {$hps_emac1_rmii_en == 1 || $hps_emac1_rgmii_en == 1} {
-output   wire        hps_emac1_TX_CLK,       
-input    wire        hps_emac1_RX_CLK,      
+output   wire        hps_emac1_TX_CLK,
+input    wire        hps_emac1_RX_CLK,
 output   wire        hps_emac1_TX_CTL,
-input    wire        hps_emac1_RX_CTL,      
-output   wire        hps_emac1_TXD0,       
+input    wire        hps_emac1_RX_CTL,
+output   wire        hps_emac1_TXD0,
 output   wire        hps_emac1_TXD1,
-input    wire        hps_emac1_RXD0,     
-input    wire        hps_emac1_RXD1,   
+input    wire        hps_emac1_RXD0,
+input    wire        hps_emac1_RXD1,
 @@}
 @@if {$hps_emac1_rgmii_en == 1} {
-output   wire        hps_emac1_TXD2,        
+output   wire        hps_emac1_TXD2,
 output   wire        hps_emac1_TXD3,
-input    wire        hps_emac1_RXD2,        
+input    wire        hps_emac1_RXD2,
 input    wire        hps_emac1_RXD3,
 @@}
 @@if {$hps_mdio1_q1_en == 1 || $hps_mdio1_q4_en == 1} {
-inout    wire        hps_emac1_MDIO,         
+inout    wire        hps_emac1_MDIO,
 output   wire        hps_emac1_MDC,
 @@}
 @@if {$hps_emac2_rmii_en == 1 || $hps_emac2_rgmii_en == 1} {
-output   wire        hps_emac2_TX_CLK,       
-input    wire        hps_emac2_RX_CLK,      
+output   wire        hps_emac2_TX_CLK,
+input    wire        hps_emac2_RX_CLK,
 output   wire        hps_emac2_TX_CTL,
-input    wire        hps_emac2_RX_CTL,      
-output   wire        hps_emac2_TXD0,       
+input    wire        hps_emac2_RX_CTL,
+output   wire        hps_emac2_TXD0,
 output   wire        hps_emac2_TXD1,
-input    wire        hps_emac2_RXD0,     
-input    wire        hps_emac2_RXD1, 
+input    wire        hps_emac2_RXD0,
+input    wire        hps_emac2_RXD1,
 @@}
 @@if {$hps_emac2_rgmii_en == 1} {
-output   wire        hps_emac2_TXD2,        
+output   wire        hps_emac2_TXD2,
 output   wire        hps_emac2_TXD3,
-input    wire        hps_emac2_RXD2,        
+input    wire        hps_emac2_RXD2,
 input    wire        hps_emac2_RXD3,
 @@}
 @@if {$hps_mdio2_q1_en == 1 || $hps_mdio2_q3_en == 1} {
-inout    wire        hps_emac2_MDIO,         
+inout    wire        hps_emac2_MDIO,
 output   wire        hps_emac2_MDC,
 @@}
 @@if {$hps_spim0_q1_en == 1 || $hps_spim0_q4_en == 1} {
@@ -294,40 +294,40 @@ output   wire        hps_spis1_MISO,
 input    wire        hps_spis1_SS0_N,
 @@}
 @@if {$hps_uart0_q1_en == 1 || $hps_uart0_q2_en == 1 || $hps_uart0_q3_en == 1} {
-input    wire        hps_uart0_RX,       
-output   wire        hps_uart0_TX, 
+input    wire        hps_uart0_RX,
+output   wire        hps_uart0_TX,
 @@}
 @@if {$hps_uart0_fc_en == 1} {
-input    wire        hps_uart0_CTS_N,       
-output   wire        hps_uart0_RTS_N, 
+input    wire        hps_uart0_CTS_N,
+output   wire        hps_uart0_RTS_N,
 @@}
 @@if {$hps_uart1_q1_en == 1 || $hps_uart1_q3_en == 1 || $hps_uart1_q4_en == 1} {
-input    wire        hps_uart1_RX,       
-output   wire        hps_uart1_TX, 
+input    wire        hps_uart1_RX,
+output   wire        hps_uart1_TX,
 @@}
 @@if {$hps_uart1_fc_en == 1} {
-input    wire        hps_uart1_CTS_N,       
-output   wire        hps_uart1_RTS_N, 
+input    wire        hps_uart1_CTS_N,
+output   wire        hps_uart1_RTS_N,
 @@}
 @@if {$hps_i2c0_q1_en == 1 || $hps_i2c0_q2_en == 1 || $hps_i2c0_q3_en == 1} {
-inout    wire        hps_i2c0_SDA,        
-inout    wire        hps_i2c0_SCL, 
+inout    wire        hps_i2c0_SDA,
+inout    wire        hps_i2c0_SCL,
 @@}
 @@if {$hps_i2c1_q1_en == 1 || $hps_i2c1_q2_en == 1 || $hps_i2c1_q3_en == 1 || $hps_i2c1_q4_en == 1} {
-inout    wire        hps_i2c1_SDA,        
-inout    wire        hps_i2c1_SCL, 
+inout    wire        hps_i2c1_SDA,
+inout    wire        hps_i2c1_SCL,
 @@}
 @@if {$hps_i2c_emac0_q1_en == 1 || $hps_i2c_emac0_q3_en == 1 || $hps_i2c_emac0_q4_en == 1} {
-inout    wire        hps_i2c_emac0_SDA,        
-inout    wire        hps_i2c_emac0_SCL,  
+inout    wire        hps_i2c_emac0_SDA,
+inout    wire        hps_i2c_emac0_SCL,
 @@}
 @@if {$hps_i2c_emac1_q1_en == 1 || $hps_i2c_emac1_q4_en == 1} {
-inout    wire        hps_i2c_emac1_SDA,        
-inout    wire        hps_i2c_emac1_SCL,  
+inout    wire        hps_i2c_emac1_SDA,
+inout    wire        hps_i2c_emac1_SCL,
 @@}
 @@if {$hps_i2c_emac2_q1_en == 1 || $hps_i2c_emac2_q3_en == 1 || $hps_i2c_emac2_q4_en == 1} {
-inout    wire        hps_i2c_emac2_SDA,        
-inout    wire        hps_i2c_emac2_SCL,  
+inout    wire        hps_i2c_emac2_SDA,
+inout    wire        hps_i2c_emac2_SCL,
 @@}
 @@if {$hps_nand_q12_en == 1 || $hps_nand_q34_en == 1} {
 output   wire        hps_nand_ALE,
@@ -357,29 +357,29 @@ inout    wire        hps_nand_ADQ14,
 inout    wire        hps_nand_ADQ15,
 @@}
 @@if {$hps_trace_q12_en == 1 || $hps_trace_q34_en == 1} {
-output   wire        hps_trace_CLK, 
-output   wire        hps_trace_D0, 
-output   wire        hps_trace_D1, 
-output   wire        hps_trace_D2, 
+output   wire        hps_trace_CLK,
+output   wire        hps_trace_D0,
+output   wire        hps_trace_D1,
+output   wire        hps_trace_D2,
 output   wire        hps_trace_D3,
 @@}
 @@if {$hps_trace_8b_en == 1 || $hps_trace_12b_en ==1 || $hps_trace_16b_en ==1} {
 output   wire        hps_trace_D4,
-output   wire        hps_trace_D5, 
-output   wire        hps_trace_D6, 
-output   wire        hps_trace_D7, 
+output   wire        hps_trace_D5,
+output   wire        hps_trace_D6,
+output   wire        hps_trace_D7,
 @@}
 @@if {$hps_trace_12b_en == 1 || $hps_trace_16b_en ==1} {
 output   wire        hps_trace_D8,
-output   wire        hps_trace_D9, 
-output   wire        hps_trace_D10, 
-output   wire        hps_trace_D11, 
+output   wire        hps_trace_D9,
+output   wire        hps_trace_D10,
+output   wire        hps_trace_D11,
 @@}
 @@if {$hps_trace_16b_en == 1} {
 output   wire        hps_trace_D12,
-output   wire        hps_trace_D13, 
-output   wire        hps_trace_D14, 
-output   wire        hps_trace_D15, 
+output   wire        hps_trace_D13,
+output   wire        hps_trace_D14,
+output   wire        hps_trace_D15,
 @@}
 @@if {$hps_gpio0_en == 1} {
 @@  foreach io_num $hps_gpio0_list {
@@ -409,14 +409,14 @@ input    wire        hps_ref_clk,
 @@}
 @@if {$hbm_en == 1} {
 // Ports when HBMe enabled
-input  wire        hbm_core_pll_refclk_clk,       
-input  wire        hbm_cattrip_virtual_i_conduit, 
-input  wire [2:0]  hbm_temp_virtual_i_conduit,    
-input  wire        uibpll_refclk_clk,             
+input  wire        hbm_core_pll_refclk_clk,
+input  wire        hbm_cattrip_virtual_i_conduit,
+input  wire [2:0]  hbm_temp_virtual_i_conduit,
+input  wire        uibpll_refclk_clk,
 input  wire        hbm_only_reset_reset,
-@@}  
+@@}
 
-input    wire [1-1:0]   fpga_reset_n      
+input   wire         fpga_reset_n
 );
 
 wire         system_clk_100;
@@ -537,12 +537,12 @@ wire        pr_handshake_stop_req_ack_loopback_wire_${m};
 @@  for {set m 0} {$m<$pr_region_count} {incr m} {
 wire        pr_handshake_start_req_ack_loopback_wire_delay_ver_${m};
 wire        pr_handshake_stop_req_ack_loopback_wire_delay_ver_${m};
-wire        freeze_wire_${m};     
-wire        illegal_request_wire_${m}; 
+wire        freeze_wire_${m};
+wire        illegal_request_wire_${m};
 @@}
 wire [31:0]    start_ack_delay_cnt;
 wire [31:0]    stop_ack_delay_cnt;
-@@}  
+@@}
 @@}
 
 @@if {$hps_stm_en == 1} {
@@ -564,7 +564,7 @@ wire [43:0]    stm_hw_events;
 @@	incr stm_hw_events_option_bitcount $fpga_button_pio_width
 @@ }
 @@# calculate remaining bit to set '0'
-@@ set stm_hw_events_option_bitcount [expr {32 - $stm_hw_events_option_bitcount}] 
+@@ set stm_hw_events_option_bitcount [expr {32 - $stm_hw_events_option_bitcount}]
 assign stm_hw_events    = {{${stm_hw_events_option_bitcount}{1'b0}}${stm_hw_events_option}};
 @@} else {
 assign stm_hw_events    = 44'b0;
@@ -669,7 +669,7 @@ ${qsys_name} soc_inst (
 //.src_prb_rst_sources_source             (src_reset_n),
 @@}
 @@if {($h2f_user0_clk_en == 1 && $hps_en == 1)} {
-.h2f_user_clk_clk                       (h2f_user_clk_clk), 
+.h2f_user_clk_clk                       (h2f_user_clk_clk),
 @@}
 .clk_100_clk                            (system_clk_100_internal),
 @@if {$hbm_en != 1} {
@@ -685,21 +685,21 @@ ${qsys_name} soc_inst (
 .led_pio_external_connection_in_port    (fpga_led_internal),
 .led_pio_external_connection_out_port   (fpga_led_internal),
 @@}
-@@ if {$fpga_dipsw_pio_width != 0} {                
+@@ if {$fpga_dipsw_pio_width != 0} {
 .dipsw_pio_external_connection_export   (fpga_dipsw_pio),
 @@}
-@@ if {$fpga_button_pio_width != 0} {  
+@@ if {$fpga_button_pio_width != 0} {
 .button_pio_external_connection_export  (fpga_debounced_buttons),
 @@}
 @@}
-@@if {$fpga_pcie == 1} {  
+@@if {$fpga_pcie == 1} {
 .pcie_hip_refclk0_clk                   (pcie_hip_refclk0_clk),
 .pcie_hip_refclk1_clk                   (pcie_hip_refclk1_clk),
-@@  for {set j 0} {$j<16} {incr j} { 
-.pcie_hip_serial_rx_n_in${j}            (pcie_hip_serial_rx_n_in[${j}]),                                
-.pcie_hip_serial_rx_p_in${j}            (pcie_hip_serial_rx_p_in[${j}]),                                
-.pcie_hip_serial_tx_n_out${j}           (pcie_hip_serial_tx_n_out[${j}]), 
-.pcie_hip_serial_tx_p_out${j}           (pcie_hip_serial_tx_p_out[${j}]), 
+@@  for {set j 0} {$j<16} {incr j} {
+.pcie_hip_serial_rx_n_in${j}            (pcie_hip_serial_rx_n_in[${j}]),
+.pcie_hip_serial_rx_p_in${j}            (pcie_hip_serial_rx_p_in[${j}]),
+.pcie_hip_serial_tx_n_out${j}           (pcie_hip_serial_tx_n_out[${j}]),
+.pcie_hip_serial_tx_p_out${j}           (pcie_hip_serial_tx_p_out[${j}]),
 @@}
 .pcie_hip_perst_pin_perst               (pcie_hip_npor_pin_perst),
 .pcie_ninit_done_ninit_done             (ninit_done),
@@ -727,53 +727,53 @@ ${qsys_name} soc_inst (
 .qsfpdd_i2c_sda_i                       (qsfpdd_i2c_sda),
 .qsfpdd_i2c_sda_oe                      (qsfpdd_i2c_sda_oe),
 @@}
-@@if {$hps_en == 1} {     
+@@if {$hps_en == 1} {
 @@if {$hps_stm_en == 1} {
-.agilex_hps_f2h_stm_hw_events_stm_hwevents (stm_hw_events),     
+.agilex_hps_f2h_stm_hw_events_stm_hwevents (stm_hw_events),
 //Terminate the CS_JTAG.
-.agilex_hps_h2f_cs_ntrst                   (1'b1),  
-.agilex_hps_h2f_cs_tck                     (1'b1),    
-.agilex_hps_h2f_cs_tdi                     (1'b1),    
-.agilex_hps_h2f_cs_tdo                     (),    
-.agilex_hps_h2f_cs_tdoen                   (),  
-.agilex_hps_h2f_cs_tms                     (1'b1),    
+.agilex_hps_h2f_cs_ntrst                   (1'b1),
+.agilex_hps_h2f_cs_tck                     (1'b1),
+.agilex_hps_h2f_cs_tdi                     (1'b1),
+.agilex_hps_h2f_cs_tdo                     (),
+.agilex_hps_h2f_cs_tdoen                   (),
+.agilex_hps_h2f_cs_tms                     (1'b1),
 @@}
 @@if {$hps_emif_en == 1} {
 @@if {$hps_emif_type == "ddr4"} {
-.emif_hps_pll_ref_clk_clk               (emif_hps_pll_ref_clk),   
-.emif_hps_mem_mem_ck                    (emif_hps_mem_mem_ck),   
-.emif_hps_mem_mem_ck_n                  (emif_hps_mem_mem_ck_n),  
-.emif_hps_mem_mem_a                     (emif_hps_mem_mem_a),       
-.emif_hps_mem_mem_act_n                 (emif_hps_mem_mem_act_n),   
-.emif_hps_mem_mem_ba                    (emif_hps_mem_mem_ba),      
-.emif_hps_mem_mem_bg                    (emif_hps_mem_mem_bg),      
-.emif_hps_mem_mem_cke                   (emif_hps_mem_mem_cke),    
-.emif_hps_mem_mem_cs_n                  (emif_hps_mem_mem_cs_n),    
-.emif_hps_mem_mem_odt                   (emif_hps_mem_mem_odt),     
+.emif_hps_pll_ref_clk_clk               (emif_hps_pll_ref_clk),
+.emif_hps_mem_mem_ck                    (emif_hps_mem_mem_ck),
+.emif_hps_mem_mem_ck_n                  (emif_hps_mem_mem_ck_n),
+.emif_hps_mem_mem_a                     (emif_hps_mem_mem_a),
+.emif_hps_mem_mem_act_n                 (emif_hps_mem_mem_act_n),
+.emif_hps_mem_mem_ba                    (emif_hps_mem_mem_ba),
+.emif_hps_mem_mem_bg                    (emif_hps_mem_mem_bg),
+.emif_hps_mem_mem_cke                   (emif_hps_mem_mem_cke),
+.emif_hps_mem_mem_cs_n                  (emif_hps_mem_mem_cs_n),
+.emif_hps_mem_mem_odt                   (emif_hps_mem_mem_odt),
 .emif_hps_mem_mem_reset_n               (emif_hps_mem_mem_reset_n),
-.emif_hps_mem_mem_par                   (emif_hps_mem_mem_par),          
-.emif_hps_mem_mem_alert_n               (emif_hps_mem_mem_alert_n),    
-.emif_hps_mem_mem_dqs                   (emif_hps_mem_mem_dqs),       
-.emif_hps_mem_mem_dqs_n                 (emif_hps_mem_mem_dqs_n),     
-.emif_hps_mem_mem_dq                    (emif_hps_mem_mem_dq), 
-.emif_hps_mem_mem_dbi_n                 (emif_hps_mem_mem_dbi_n), 
-.emif_hps_oct_oct_rzqin                 (emif_hps_oct_oct_rzqin), 
+.emif_hps_mem_mem_par                   (emif_hps_mem_mem_par),
+.emif_hps_mem_mem_alert_n               (emif_hps_mem_mem_alert_n),
+.emif_hps_mem_mem_dqs                   (emif_hps_mem_mem_dqs),
+.emif_hps_mem_mem_dqs_n                 (emif_hps_mem_mem_dqs_n),
+.emif_hps_mem_mem_dq                    (emif_hps_mem_mem_dq),
+.emif_hps_mem_mem_dbi_n                 (emif_hps_mem_mem_dbi_n),
+.emif_hps_oct_oct_rzqin                 (emif_hps_oct_oct_rzqin),
 @@}
 @@if {$hps_emif_type == "ddr5"} {
 .emif_hps_noc_pll_lock_o_pll_lock_o     (emif_hps_noc_pll_lock_o_pll_lock_o),
 .emif_hps_noc_refclk_clk                (emif_hps_noc_refclk_clk),
-.emif_hps_emif_mem_ck_0_mem_ck_c        (emif_hps_mem_mem_ck_c),   
-.emif_hps_emif_mem_ck_0_mem_ck_t        (emif_hps_mem_mem_ck_t),  
-.emif_hps_emif_mem_0_mem_ca             (emif_hps_mem_mem_ca),       
-.emif_hps_emif_mem_0_mem_cs_n           (emif_hps_mem_mem_cs_n),    
+.emif_hps_emif_mem_ck_0_mem_ck_c        (emif_hps_mem_mem_ck_c),
+.emif_hps_emif_mem_ck_0_mem_ck_t        (emif_hps_mem_mem_ck_t),
+.emif_hps_emif_mem_0_mem_ca             (emif_hps_mem_mem_ca),
+.emif_hps_emif_mem_0_mem_cs_n           (emif_hps_mem_mem_cs_n),
 .emif_hps_emif_mem_reset_n_mem_reset_n               (emif_hps_mem_mem_reset_n),
-.emif_hps_emif_mem_0_mem_dm_n                  (emif_hps_mem_mem_dm_n), 
-.emif_hps_emif_mem_0_mem_alert_n               (emif_hps_mem_mem_alert_n),    
+.emif_hps_emif_mem_0_mem_dm_n                  (emif_hps_mem_mem_dm_n),
+.emif_hps_emif_mem_0_mem_alert_n               (emif_hps_mem_mem_alert_n),
 .emif_hps_emif_oct_0_oct_rzqin                 (emif_hps_oct_oct_rzqin),
 .emif_hps_emif_ref_clk_0_clk                   (emif_hps_ref_clk_clk),
-.emif_hps_emif_mem_0_mem_dq                    (emif_hps_mem_mem_dq),       
-.emif_hps_emif_mem_0_mem_dqs_c                 (emif_hps_mem_mem_dqs_c), 
-.emif_hps_emif_mem_0_mem_dqs_t                 (emif_hps_mem_mem_dqs_t), 
+.emif_hps_emif_mem_0_mem_dq                    (emif_hps_mem_mem_dq),
+.emif_hps_emif_mem_0_mem_dqs_c                 (emif_hps_mem_mem_dqs_c),
+.emif_hps_emif_mem_0_mem_dqs_t                 (emif_hps_mem_mem_dqs_t),
 @@}
 @@} else {
 @@if {$hbm_en == 1 } {
@@ -782,83 +782,83 @@ ${qsys_name} soc_inst (
 @@}
 @@}
 @@if {$hps_jtag_en == 1} {
-.hps_io_jtag_tck                 (hps_jtag_tck),                
-.hps_io_jtag_tms                 (hps_jtag_tms),                
-.hps_io_jtag_tdo                 (hps_jtag_tdo),                 
-.hps_io_jtag_tdi                 (hps_jtag_tdi),    
+.hps_io_jtag_tck                 (hps_jtag_tck),
+.hps_io_jtag_tms                 (hps_jtag_tms),
+.hps_io_jtag_tdo                 (hps_jtag_tdo),
+.hps_io_jtag_tdi                 (hps_jtag_tdi),
 @@}
 @@if {$hps_emac0_rmii_en == 1 || $hps_emac0_rgmii_en == 1} {
-.hps_io_EMAC0_TX_CLK       (hps_emac0_TX_CLK),     
-.hps_io_EMAC0_RX_CLK       (hps_emac0_RX_CLK),     
-.hps_io_EMAC0_TX_CTL       (hps_emac0_TX_CTL),    
-.hps_io_EMAC0_RX_CTL       (hps_emac0_RX_CTL),    
-.hps_io_EMAC0_TXD0         (hps_emac0_TXD0),     
+.hps_io_EMAC0_TX_CLK       (hps_emac0_TX_CLK),
+.hps_io_EMAC0_RX_CLK       (hps_emac0_RX_CLK),
+.hps_io_EMAC0_TX_CTL       (hps_emac0_TX_CTL),
+.hps_io_EMAC0_RX_CTL       (hps_emac0_RX_CTL),
+.hps_io_EMAC0_TXD0         (hps_emac0_TXD0),
 .hps_io_EMAC0_TXD1         (hps_emac0_TXD1),
-.hps_io_EMAC0_RXD0         (hps_emac0_RXD0),       
-.hps_io_EMAC0_RXD1         (hps_emac0_RXD1),        
+.hps_io_EMAC0_RXD0         (hps_emac0_RXD0),
+.hps_io_EMAC0_RXD1         (hps_emac0_RXD1),
 @@}
 @@if {$hps_emac0_rgmii_en == 1} {
-.hps_io_EMAC0_TXD2         (hps_emac0_TXD2),      
-.hps_io_EMAC0_TXD3         (hps_emac0_TXD3),   
-.hps_io_EMAC0_RXD2         (hps_emac0_RXD2),        
+.hps_io_EMAC0_TXD2         (hps_emac0_TXD2),
+.hps_io_EMAC0_TXD3         (hps_emac0_TXD3),
+.hps_io_EMAC0_RXD2         (hps_emac0_RXD2),
 .hps_io_EMAC0_RXD3         (hps_emac0_RXD3),
 @@}
 @@if {$hps_mdio0_q1_en == 1 || $hps_mdio0_q3_en == 1 || $hps_mdio0_q4_en == 1} {
-.hps_io_EMAC0_MDIO         (hps_emac0_MDIO),       
-.hps_io_EMAC0_MDC          (hps_emac0_MDC), 
+.hps_io_EMAC0_MDIO         (hps_emac0_MDIO),
+.hps_io_EMAC0_MDC          (hps_emac0_MDC),
 @@}
 @@if {$hps_emac1_rmii_en == 1 || $hps_emac1_rgmii_en == 1} {
-.hps_io_EMAC1_TX_CLK       (hps_emac1_TX_CLK),     
-.hps_io_EMAC1_RX_CLK       (hps_emac1_RX_CLK),     
-.hps_io_EMAC1_TX_CTL       (hps_emac1_TX_CTL),    
-.hps_io_EMAC1_RX_CTL       (hps_emac1_RX_CTL),    
-.hps_io_EMAC1_TXD0         (hps_emac1_TXD0),     
+.hps_io_EMAC1_TX_CLK       (hps_emac1_TX_CLK),
+.hps_io_EMAC1_RX_CLK       (hps_emac1_RX_CLK),
+.hps_io_EMAC1_TX_CTL       (hps_emac1_TX_CTL),
+.hps_io_EMAC1_RX_CTL       (hps_emac1_RX_CTL),
+.hps_io_EMAC1_TXD0         (hps_emac1_TXD0),
 .hps_io_EMAC1_TXD1         (hps_emac1_TXD1),
-.hps_io_EMAC1_RXD0         (hps_emac1_RXD0),       
-.hps_io_EMAC1_RXD1         (hps_emac1_RXD1),        
+.hps_io_EMAC1_RXD0         (hps_emac1_RXD0),
+.hps_io_EMAC1_RXD1         (hps_emac1_RXD1),
 @@}
-@@if {$hps_emac1_rgmii_en == 1} {    
-.hps_io_EMAC1_TXD2         (hps_emac1_TXD2),      
-.hps_io_EMAC1_TXD3         (hps_emac1_TXD3),   
-.hps_io_EMAC1_RXD2         (hps_emac1_RXD2),        
+@@if {$hps_emac1_rgmii_en == 1} {
+.hps_io_EMAC1_TXD2         (hps_emac1_TXD2),
+.hps_io_EMAC1_TXD3         (hps_emac1_TXD3),
+.hps_io_EMAC1_RXD2         (hps_emac1_RXD2),
 .hps_io_EMAC1_RXD3         (hps_emac1_RXD3),
 @@}
 @@if {$hps_mdio1_q1_en == 1 || $hps_mdio1_q4_en == 1} {
-.hps_io_EMAC1_MDIO         (hps_emac1_MDIO),       
-.hps_io_EMAC1_MDC          (hps_emac1_MDC), 
+.hps_io_EMAC1_MDIO         (hps_emac1_MDIO),
+.hps_io_EMAC1_MDC          (hps_emac1_MDC),
 @@}
 @@if {$hps_emac2_rmii_en == 1 || $hps_emac2_rgmii_en == 1} {
-.hps_io_EMAC2_TX_CLK       (hps_emac2_TX_CLK),      
-.hps_io_EMAC2_RX_CLK       (hps_emac2_RX_CLK),  
-.hps_io_EMAC2_TX_CTL       (hps_emac2_TX_CTL),     
-.hps_io_EMAC2_RX_CTL       (hps_emac2_RX_CTL),  
-.hps_io_EMAC2_TXD0         (hps_emac2_TXD0),        
-.hps_io_EMAC2_TXD1         (hps_emac2_TXD1),  
-.hps_io_EMAC2_RXD0         (hps_emac2_RXD0),   
-.hps_io_EMAC2_RXD1         (hps_emac2_RXD1),     
+.hps_io_EMAC2_TX_CLK       (hps_emac2_TX_CLK),
+.hps_io_EMAC2_RX_CLK       (hps_emac2_RX_CLK),
+.hps_io_EMAC2_TX_CTL       (hps_emac2_TX_CTL),
+.hps_io_EMAC2_RX_CTL       (hps_emac2_RX_CTL),
+.hps_io_EMAC2_TXD0         (hps_emac2_TXD0),
+.hps_io_EMAC2_TXD1         (hps_emac2_TXD1),
+.hps_io_EMAC2_RXD0         (hps_emac2_RXD0),
+.hps_io_EMAC2_RXD1         (hps_emac2_RXD1),
 @@}
 @@if {$hps_emac2_rgmii_en == 1} {
-.hps_io_EMAC2_TXD2         (hps_emac2_TXD2),      
-.hps_io_EMAC2_TXD3         (hps_emac2_TXD3),  
-.hps_io_EMAC2_RXD2         (hps_emac2_RXD2),     
-.hps_io_EMAC2_RXD3         (hps_emac2_RXD3),   
+.hps_io_EMAC2_TXD2         (hps_emac2_TXD2),
+.hps_io_EMAC2_TXD3         (hps_emac2_TXD3),
+.hps_io_EMAC2_RXD2         (hps_emac2_RXD2),
+.hps_io_EMAC2_RXD3         (hps_emac2_RXD3),
 @@}
 @@if {$hps_mdio2_q1_en == 1 || $hps_mdio2_q3_en == 1} {
-.hps_io_EMAC2_MDIO         (hps_emac2_MDIO),  
-.hps_io_EMAC2_MDC          (hps_emac2_MDC),  
+.hps_io_EMAC2_MDIO         (hps_emac2_MDIO),
+.hps_io_EMAC2_MDC          (hps_emac2_MDC),
 @@}
 @@if {$hps_sdmmc4b_q1_en == 1 || $hps_sdmmc8b_q1_en == 1 || $hps_sdmmc4b_q4_en == 1 || $hps_sdmmc8b_q4_en == 1} {
-.hps_io_SDMMC_CCLK         (hps_sdmmc_CCLK),   
-.hps_io_SDMMC_CMD          (hps_sdmmc_CMD), 
-.hps_io_SDMMC_D0           (hps_sdmmc_D0),          
-.hps_io_SDMMC_D1           (hps_sdmmc_D1),          
-.hps_io_SDMMC_D2           (hps_sdmmc_D2),         
-.hps_io_SDMMC_D3           (hps_sdmmc_D3),        
+.hps_io_SDMMC_CCLK         (hps_sdmmc_CCLK),
+.hps_io_SDMMC_CMD          (hps_sdmmc_CMD),
+.hps_io_SDMMC_D0           (hps_sdmmc_D0),
+.hps_io_SDMMC_D1           (hps_sdmmc_D1),
+.hps_io_SDMMC_D2           (hps_sdmmc_D2),
+.hps_io_SDMMC_D3           (hps_sdmmc_D3),
 @@}
 @@if {$hps_sdmmc8b_q1_en == 1 || $hps_sdmmc8b_q4_en == 1} {
-.hps_io_SDMMC_D4           (hps_sdmmc_D4),          
-.hps_io_SDMMC_D5           (hps_sdmmc_D5),          
-.hps_io_SDMMC_D6           (hps_sdmmc_D6),         
+.hps_io_SDMMC_D4           (hps_sdmmc_D4),
+.hps_io_SDMMC_D5           (hps_sdmmc_D5),
+.hps_io_SDMMC_D6           (hps_sdmmc_D6),
 .hps_io_SDMMC_D7           (hps_sdmmc_D7),
 @@}
 @@if {$hps_nand_q12_en == 1 || $hps_nand_q34_en == 1} {
@@ -889,45 +889,45 @@ ${qsys_name} soc_inst (
 .hps_io_NAND_ADQ15         (hps_nand_ADQ15),
 @@}
 @@if {$hps_i2c0_q1_en == 1 || $hps_i2c0_q2_en == 1 || $hps_i2c0_q3_en == 1} {
-.hps_io_I2C0_SDA           (hps_i2c0_SDA),     
+.hps_io_I2C0_SDA           (hps_i2c0_SDA),
 .hps_io_I2C0_SCL           (hps_i2c0_SCL),
 @@}
 @@if {$hps_i2c1_q1_en == 1 || $hps_i2c1_q2_en == 1 || $hps_i2c1_q3_en == 1 || $hps_i2c1_q4_en == 1} {
-.hps_io_I2C1_SDA           (hps_i2c1_SDA),     
+.hps_io_I2C1_SDA           (hps_i2c1_SDA),
 .hps_io_I2C1_SCL           (hps_i2c1_SCL),
 @@}
 @@if {$hps_i2c_emac0_q1_en == 1 || $hps_i2c_emac0_q3_en == 1 || $hps_i2c_emac0_q4_en == 1} {
-.hps_io_I2CEMAC0_SDA       (hps_i2c_emac0_SDA),       
-.hps_io_I2CEMAC0_SCL       (hps_i2c_emac0_SCL),                  
+.hps_io_I2CEMAC0_SDA       (hps_i2c_emac0_SDA),
+.hps_io_I2CEMAC0_SCL       (hps_i2c_emac0_SCL),
 @@}
 @@if {$hps_i2c_emac1_q1_en == 1 || $hps_i2c_emac1_q4_en == 1} {
-.hps_io_I2CEMAC1_SDA       (hps_i2c_emac1_SDA),       
-.hps_io_I2CEMAC1_SCL       (hps_i2c_emac1_SCL),                  
+.hps_io_I2CEMAC1_SDA       (hps_i2c_emac1_SDA),
+.hps_io_I2CEMAC1_SCL       (hps_i2c_emac1_SCL),
 @@}
 @@if {$hps_i2c_emac2_q1_en == 1 || $hps_i2c_emac2_q3_en == 1 || $hps_i2c_emac2_q4_en == 1} {
-.hps_io_I2CEMAC2_SDA       (hps_i2c_emac2_SDA),       
-.hps_io_I2CEMAC2_SCL       (hps_i2c_emac2_SCL),                  
+.hps_io_I2CEMAC2_SDA       (hps_i2c_emac2_SDA),
+.hps_io_I2CEMAC2_SCL       (hps_i2c_emac2_SCL),
 @@}
 @@if {$hps_uart0_q1_en == 1 || $hps_uart0_q2_en == 1 || $hps_uart0_q3_en == 1} {
-.hps_io_UART0_RX           (hps_uart0_RX),          
-.hps_io_UART0_TX           (hps_uart0_TX), 
-@@}                                 
+.hps_io_UART0_RX           (hps_uart0_RX),
+.hps_io_UART0_TX           (hps_uart0_TX),
+@@}
 @@if {$hps_uart0_fc_en == 1} {
-.hps_io_UART0_CTS_N        (hps_uart0_CTS_N),  
-.hps_io_UART0_RTS_N        (hps_uart0_RTS_N),  
+.hps_io_UART0_CTS_N        (hps_uart0_CTS_N),
+.hps_io_UART0_RTS_N        (hps_uart0_RTS_N),
 @@}
 @@if {$hps_uart1_q1_en == 1 || $hps_uart1_q3_en == 1 || $hps_uart1_q4_en == 1} {
-.hps_io_UART1_RX           (hps_uart1_RX),          
-.hps_io_UART1_TX           (hps_uart1_TX), 
+.hps_io_UART1_RX           (hps_uart1_RX),
+.hps_io_UART1_TX           (hps_uart1_TX),
 @@}
 @@if {$hps_uart1_fc_en == 1} {
-.hps_io_UART1_CTS_N        (hps_uart1_CTS_N),  
-.hps_io_UART1_RTS_N        (hps_uart1_RTS_N),  
+.hps_io_UART1_CTS_N        (hps_uart1_CTS_N),
+.hps_io_UART1_RTS_N        (hps_uart1_RTS_N),
 @@}
 @@if {$hps_spim0_q1_en == 1 || $hps_spim0_q4_en == 1 } {
 .hps_io_SPIM0_CLK          (hps_spim0_CLK),
 .hps_io_SPIM0_MOSI         (hps_spim0_MOSI),
-.hps_io_SPIM0_MISO         (hps_spim0_MISO), 
+.hps_io_SPIM0_MISO         (hps_spim0_MISO),
 .hps_io_SPIM0_SS0_N        (hps_spim0_SS0_N),
 @@}
 @@if {$hps_spim0_2ss_en == 1} {
@@ -936,7 +936,7 @@ ${qsys_name} soc_inst (
 @@if {$hps_spim1_q1_en == 1 || $hps_spim1_q2_en == 1 || $hps_spim1_q3_en == 1} {
 .hps_io_SPIM1_CLK          (hps_spim1_CLK),
 .hps_io_SPIM1_MOSI         (hps_spim1_MOSI),
-.hps_io_SPIM1_MISO         (hps_spim1_MISO), 
+.hps_io_SPIM1_MISO         (hps_spim1_MISO),
 .hps_io_SPIM1_SS0_N        (hps_spim1_SS0_N),
 @@}
 @@if {$hps_spim1_2ss_en == 1} {
@@ -953,59 +953,59 @@ ${qsys_name} soc_inst (
 .hps_io_SPIS1_MOSI         (hps_spis1_MOSI),
 .hps_io_SPIS1_MISO         (hps_spis1_MISO),
 .hps_io_SPIS1_SS0_N        (hps_spis1_SS0_N),
-@@}                                  
+@@}
 @@if {$hps_usb0_en == 1} {
-.hps_io_USB0_CLK           (hps_usb0_CLK), 
-.hps_io_USB0_STP           (hps_usb0_STP), 
+.hps_io_USB0_CLK           (hps_usb0_CLK),
+.hps_io_USB0_STP           (hps_usb0_STP),
 .hps_io_USB0_DIR           (hps_usb0_DIR),
 .hps_io_USB0_NXT           (hps_usb0_NXT),
 .hps_io_USB0_DATA0         (hps_usb0_DATA0),
-.hps_io_USB0_DATA1         (hps_usb0_DATA1), 
-.hps_io_USB0_DATA2         (hps_usb0_DATA2), 
-.hps_io_USB0_DATA3         (hps_usb0_DATA3), 
-.hps_io_USB0_DATA4         (hps_usb0_DATA4), 
+.hps_io_USB0_DATA1         (hps_usb0_DATA1),
+.hps_io_USB0_DATA2         (hps_usb0_DATA2),
+.hps_io_USB0_DATA3         (hps_usb0_DATA3),
+.hps_io_USB0_DATA4         (hps_usb0_DATA4),
 .hps_io_USB0_DATA5         (hps_usb0_DATA5),
-.hps_io_USB0_DATA6         (hps_usb0_DATA6), 
+.hps_io_USB0_DATA6         (hps_usb0_DATA6),
 .hps_io_USB0_DATA7         (hps_usb0_DATA7),
 @@}
 @@if {$hps_usb1_en == 1} {
-.hps_io_USB1_CLK           (hps_usb1_CLK), 
-.hps_io_USB1_STP           (hps_usb1_STP), 
+.hps_io_USB1_CLK           (hps_usb1_CLK),
+.hps_io_USB1_STP           (hps_usb1_STP),
 .hps_io_USB1_DIR           (hps_usb1_DIR),
 .hps_io_USB1_NXT           (hps_usb1_NXT),
 .hps_io_USB1_DATA0         (hps_usb1_DATA0),
-.hps_io_USB1_DATA1         (hps_usb1_DATA1), 
-.hps_io_USB1_DATA2         (hps_usb1_DATA2), 
-.hps_io_USB1_DATA3         (hps_usb1_DATA3), 
-.hps_io_USB1_DATA4         (hps_usb1_DATA4), 
+.hps_io_USB1_DATA1         (hps_usb1_DATA1),
+.hps_io_USB1_DATA2         (hps_usb1_DATA2),
+.hps_io_USB1_DATA3         (hps_usb1_DATA3),
+.hps_io_USB1_DATA4         (hps_usb1_DATA4),
 .hps_io_USB1_DATA5         (hps_usb1_DATA5),
-.hps_io_USB1_DATA6         (hps_usb1_DATA6), 
+.hps_io_USB1_DATA6         (hps_usb1_DATA6),
 .hps_io_USB1_DATA7         (hps_usb1_DATA7),
 @@}
 @@if {$hps_trace_q12_en == 1 || $hps_trace_q34_en == 1} {
-.hps_io_TRACE_CLK          (hps_trace_CLK),  
-.hps_io_TRACE_D0           (hps_trace_D0),  
-.hps_io_TRACE_D1           (hps_trace_D1),  
-.hps_io_TRACE_D2           (hps_trace_D2),  
-.hps_io_TRACE_D3           (hps_trace_D3),  
+.hps_io_TRACE_CLK          (hps_trace_CLK),
+.hps_io_TRACE_D0           (hps_trace_D0),
+.hps_io_TRACE_D1           (hps_trace_D1),
+.hps_io_TRACE_D2           (hps_trace_D2),
+.hps_io_TRACE_D3           (hps_trace_D3),
 @@}
 @@if {$hps_trace_8b_en == 1 || $hps_trace_12b_en ==1 || $hps_trace_16b_en ==1} {
-.hps_io_TRACE_D4           (hps_trace_D4),  
-.hps_io_TRACE_D5           (hps_trace_D5),  
-.hps_io_TRACE_D6           (hps_trace_D6),  
-.hps_io_TRACE_D7           (hps_trace_D7),  
+.hps_io_TRACE_D4           (hps_trace_D4),
+.hps_io_TRACE_D5           (hps_trace_D5),
+.hps_io_TRACE_D6           (hps_trace_D6),
+.hps_io_TRACE_D7           (hps_trace_D7),
 @@}
 @@if {$hps_trace_12b_en ==1 || $hps_trace_16b_en ==1} {
-.hps_io_TRACE_D8           (hps_trace_D8),  
-.hps_io_TRACE_D9           (hps_trace_D9),  
-.hps_io_TRACE_D10          (hps_trace_D10),  
-.hps_io_TRACE_D11          (hps_trace_D11), 
+.hps_io_TRACE_D8           (hps_trace_D8),
+.hps_io_TRACE_D9           (hps_trace_D9),
+.hps_io_TRACE_D10          (hps_trace_D10),
+.hps_io_TRACE_D11          (hps_trace_D11),
 @@}
 @@if {$hps_trace_16b_en ==1} {
-.hps_io_TRACE_D12          (hps_trace_D12),  
-.hps_io_TRACE_D13          (hps_trace_D13),  
-.hps_io_TRACE_D14          (hps_trace_D14),  
-.hps_io_TRACE_D15          (hps_trace_D15), 
+.hps_io_TRACE_D12          (hps_trace_D12),
+.hps_io_TRACE_D13          (hps_trace_D13),
+.hps_io_TRACE_D14          (hps_trace_D14),
+.hps_io_TRACE_D15          (hps_trace_D15),
 @@}
 @@if {$hps_gpio0_en == 1} {
 @@  foreach io_num $hps_gpio0_list {
@@ -1043,21 +1043,21 @@ ${qsys_name} soc_inst (
 @@if {$pr_enable == 1} {
 @@if {$freeze_ack_dly_enable == 1} {
 .start_ack_pio_external_connection_export  (start_ack_delay_cnt),
-.stop_ack_pio_external_connection_export   (stop_ack_delay_cnt), 
+.stop_ack_pio_external_connection_export   (stop_ack_delay_cnt),
 @@  for {set m 0} {$m<$pr_region_count} {incr m} {
 .frz_ctrl_${m}_pr_handshake_start_req      (pr_handshake_start_req_ack_loopback_wire_${m}),
-.frz_ctrl_${m}_pr_handshake_start_ack      (pr_handshake_start_req_ack_loopback_wire_delay_ver_${m}), 
+.frz_ctrl_${m}_pr_handshake_start_ack      (pr_handshake_start_req_ack_loopback_wire_delay_ver_${m}),
 .frz_ctrl_${m}_pr_handshake_stop_req       (pr_handshake_stop_req_ack_loopback_wire_${m}),
 .frz_ctrl_${m}_pr_handshake_stop_ack       (pr_handshake_stop_req_ack_loopback_wire_delay_ver_${m}),
-.frz_bdg_${m}_freeze_conduit_freeze        (freeze_wire_${m}),           
-.frz_bdg_${m}_freeze_conduit_illegal_request    (illegal_request_wire_${m}),  
-.frz_ctrl_${m}_bridge_freeze0_freeze            (freeze_wire_${m}),         
-.frz_ctrl_${m}_bridge_freeze0_illegal_request   (illegal_request_wire_${m}),  
+.frz_bdg_${m}_freeze_conduit_freeze        (freeze_wire_${m}),
+.frz_bdg_${m}_freeze_conduit_illegal_request    (illegal_request_wire_${m}),
+.frz_ctrl_${m}_bridge_freeze0_freeze            (freeze_wire_${m}),
+.frz_ctrl_${m}_bridge_freeze0_illegal_request   (illegal_request_wire_${m}),
 @@}
 @@} else {
 @@  for {set m 0} {$m<$pr_region_count} {incr m} {
 .frz_ctrl_${m}_pr_handshake_start_req      (pr_handshake_start_req_ack_loopback_wire_${m}),
-.frz_ctrl_${m}_pr_handshake_start_ack      (pr_handshake_start_req_ack_loopback_wire_${m}), 
+.frz_ctrl_${m}_pr_handshake_start_ack      (pr_handshake_start_req_ack_loopback_wire_${m}),
 .frz_ctrl_${m}_pr_handshake_stop_req       (pr_handshake_stop_req_ack_loopback_wire_${m}),
 .frz_ctrl_${m}_pr_handshake_stop_ack       (pr_handshake_stop_req_ack_loopback_wire_${m}),
 @@}
@@ -1099,26 +1099,26 @@ ${qsys_name} soc_inst (
 @@if {$fpga_emif_en == 1} {
 .fpga_emif_local_reset_req_local_reset_req     (1'b0),
 .fpga_emif_local_reset_status_local_reset_done (fpga_emif_local_reset_status_local_reset_done),
-.fpga_emif_mem_mem_ck                   (fpga_emif_mem_mem_ck),                      
-.fpga_emif_mem_mem_ck_n                 (fpga_emif_mem_mem_ck_n),                      
-.fpga_emif_mem_mem_a                    (fpga_emif_mem_mem_a),                        
-.fpga_emif_mem_mem_act_n                (fpga_emif_mem_mem_act_n),                      
-.fpga_emif_mem_mem_ba                   (fpga_emif_mem_mem_ba),                      
-.fpga_emif_mem_mem_bg                   (fpga_emif_mem_mem_bg),                         
-.fpga_emif_mem_mem_cke                  (fpga_emif_mem_mem_cke),                       
-.fpga_emif_mem_mem_cs_n                 (fpga_emif_mem_mem_cs_n),                      
-.fpga_emif_mem_mem_odt                  (fpga_emif_mem_mem_odt),                       
-.fpga_emif_mem_mem_reset_n              (fpga_emif_mem_mem_reset_n),                     
-.fpga_emif_mem_mem_par                  (fpga_emif_mem_mem_par),                         
-.fpga_emif_mem_mem_alert_n              (fpga_emif_mem_mem_alert_n),                    
-.fpga_emif_mem_mem_dqs                  (fpga_emif_mem_mem_dqs),                       
-.fpga_emif_mem_mem_dqs_n                (fpga_emif_mem_mem_dqs_n),                   
-.fpga_emif_mem_mem_dq                   (fpga_emif_mem_mem_dq),                  
-.fpga_emif_mem_mem_dbi_n                (fpga_emif_mem_mem_dbi_n),                     
-.fpga_emif_oct_oct_rzqin                (fpga_emif_oct_oct_rzqin),                     
-.fpga_emif_pll_ref_clk_clk              (fpga_emif_pll_ref_clk_clk),                   
-.fpga_emif_status_local_cal_success     (fpga_emif_status_local_cal_success),         
-.fpga_emif_status_local_cal_fail        (fpga_emif_status_local_cal_fail),          
+.fpga_emif_mem_mem_ck                   (fpga_emif_mem_mem_ck),
+.fpga_emif_mem_mem_ck_n                 (fpga_emif_mem_mem_ck_n),
+.fpga_emif_mem_mem_a                    (fpga_emif_mem_mem_a),
+.fpga_emif_mem_mem_act_n                (fpga_emif_mem_mem_act_n),
+.fpga_emif_mem_mem_ba                   (fpga_emif_mem_mem_ba),
+.fpga_emif_mem_mem_bg                   (fpga_emif_mem_mem_bg),
+.fpga_emif_mem_mem_cke                  (fpga_emif_mem_mem_cke),
+.fpga_emif_mem_mem_cs_n                 (fpga_emif_mem_mem_cs_n),
+.fpga_emif_mem_mem_odt                  (fpga_emif_mem_mem_odt),
+.fpga_emif_mem_mem_reset_n              (fpga_emif_mem_mem_reset_n),
+.fpga_emif_mem_mem_par                  (fpga_emif_mem_mem_par),
+.fpga_emif_mem_mem_alert_n              (fpga_emif_mem_mem_alert_n),
+.fpga_emif_mem_mem_dqs                  (fpga_emif_mem_mem_dqs),
+.fpga_emif_mem_mem_dqs_n                (fpga_emif_mem_mem_dqs_n),
+.fpga_emif_mem_mem_dq                   (fpga_emif_mem_mem_dq),
+.fpga_emif_mem_mem_dbi_n                (fpga_emif_mem_mem_dbi_n),
+.fpga_emif_oct_oct_rzqin                (fpga_emif_oct_oct_rzqin),
+.fpga_emif_pll_ref_clk_clk              (fpga_emif_pll_ref_clk_clk),
+.fpga_emif_status_local_cal_success     (fpga_emif_status_local_cal_success),
+.fpga_emif_status_local_cal_fail        (fpga_emif_status_local_cal_fail),
 .emif_usr_reset_n_reset_n               (emif_usr_reset_n),
 @@}
 @@if {$niosv_subsys_en == 1} {
@@ -1126,22 +1126,22 @@ ${qsys_name} soc_inst (
 .niosv_issp_reset_in_reset              (niosv_issp_reset),
 @@}
 @@if {$hbm_en == 1} {
-.hbm_core_pll_refclk_clk          	(hbm_core_pll_refclk_clk),      
+.hbm_core_pll_refclk_clk          	(hbm_core_pll_refclk_clk),
 .hbm_cattrip_virtual_i_conduit	(hbm_cattrip_virtual_i_conduit),
-.hbm_temp_virtual_i_conduit   	(hbm_temp_virtual_i_conduit),   
+.hbm_temp_virtual_i_conduit   	(hbm_temp_virtual_i_conduit),
 .uibpll_refclk_clk                          (uibpll_refclk_clk),
-.hbm_only_reset_reset            (~hbm_only_reset_reset)  
+.hbm_only_reset_reset            (~hbm_only_reset_reset)
 @@} else {
 .reset_reset_n                          (~system_reset_sync)
 @@}
-);  
+);
 
 @@if {$fpga_peripheral_en == 1} {
-@@ if {$fpga_button_pio_width != 0} {  
+@@ if {$fpga_button_pio_width != 0} {
 // Debounce logic to clean out glitches within 1ms
 debounce debounce_inst (
 .clk          (system_clk_100_internal),
-.reset_n      (~system_reset_sync),  
+.reset_n      (~system_reset_sync),
 .data_in      (fpga_button_pio),
 .data_out     (fpga_debounced_buttons)
 );
@@ -1165,19 +1165,19 @@ end
 @@  for {set m 0} {$m<$pr_region_count} {incr m} {
 ack_delay_logic start_ack_delay_logic_${m}_inst (
 .clk                                  (system_clk_100_internal),
-.reset                                (hps_fpga_reset), 
-.delay_ack_pio                        (start_ack_delay_cnt),  
+.reset                                (hps_fpga_reset),
+.delay_ack_pio                        (start_ack_delay_cnt),
 .ack_in                               (pr_handshake_start_req_ack_loopback_wire_${m}),
 .ack_delay_out                        (pr_handshake_start_req_ack_loopback_wire_delay_ver_${m})
 );
 
 ack_delay_logic stop_ack_delay_logic_${m}_inst (
 .clk                                  (system_clk_100_internal),
-.reset                                (hps_fpga_reset), 
-.delay_ack_pio                        (stop_ack_delay_cnt),  
+.reset                                (hps_fpga_reset),
+.delay_ack_pio                        (stop_ack_delay_cnt),
 .ack_in                               (pr_handshake_stop_req_ack_loopback_wire_${m}),
 .ack_delay_out                        (pr_handshake_stop_req_ack_loopback_wire_delay_ver_${m})
-); 
+);
 @@}
 @@}
 


### PR DESCRIPTION
## Release Information:
Quartus Version: 26.1 Build 110 03/26/2026 SC Pro Edition
Tag: QPDS26.1_REL_GSRD_PR
Build: socfpga_ghrd_fm_base/26.1/695

## New Features and Enhancements
- New SGMII reference design support for Agilex 7 FPGA F-Series Transceiver-SoC Development Kit (P-Tile and E-Tile) DK-SI-AGF014EB.
- New design support for eMMC binaries boot for Agilex 7 FPGA F-Series Transceiver-SoC Development Kit (P-Tile and E-Tile) DK-SI-AGF014EB

## Issues Resolved
None

## Latest Known Issues
- The performance of the SGMII reference design is not able to achieve more than 900Mbps bandwidth. This issue is expected to be fixed in the next release.