### PR TITLE
## Release Notes for **GHRD for Agilex 7 FPGA 26.1.1**

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,13 @@ $(strip $(2))-generate-design: prepare-tools | $(strip $(1))/output_files
 	$(MAKE) -C $(strip $(1)) $(strip $(4))
 
 .PHONY: $(strip $(2))-package-design
-$(strip $(2))-package-design: | $(strip $(5))
+$(strip $(2))-package-design: $(strip $(2))-generate-design | $(strip $(5))
 	cd $(strip $(1)) && zip -r $(strip $(5))/$(subst -,_,$(strip $(2))).zip * -x .gitignore "output_files/*" "qdb/*" "dni/*" "tmp-clearbox/*"
 
 .PHONY: $(strip $(2))-build
-$(strip $(2))-build: | $(strip $(1))/output_files
+$(strip $(2))-build: $(strip $(2))-generate-design | $(strip $(1))/output_files
 	cd $(strip $(1)) && quartus_sh --flow compile $(strip $(3)) -c $(strip $(3))
+	@test -f $(strip $(1))/output_files/$(strip $(3)).sof && echo "$(strip $(1))/output_files/$(strip $(3)).sof found after build flow!" || (echo "Error: $(strip $(1))/output_files/$(strip $(3)).sof not found after build flow!" && exit 1)
 
 .PHONY: $(strip $(2))-sw-build
 $(strip $(2))-sw-build:
@@ -103,6 +104,10 @@ $(strip $(2))-test:
 $(strip $(2))-install-sof: | $(strip $(5))
 	cp -f $(strip $(1))/output_files/$(strip $(3)).sof $(strip $(5))/$(subst -,_,$(strip $(2))).sof
 
+.PHONY: $(strip $(2))-install-core-rbf
+$(strip $(2))-install-core-rbf: $(strip $(1))/output_files/$(strip $(3)).sof | $(strip $(5))
+	quartus_pfg -c $(strip $(1))/output_files/$(strip $(3)).sof $(strip $(1))/output_files/ghrd.rbf -o hps=ON -o hps_core_only=ON
+	cp -f $(strip $(1))/output_files/ghrd.rbf $(strip $(5))/ghrd.core.rbf
 
 .PHONY: $(strip $(2))-all
 $(strip $(2))-all:
@@ -113,6 +118,18 @@ $(strip $(2))-all:
 	$(MAKE) $(strip $(2))-sw-build
 	$(MAKE) $(strip $(2))-test
 	$(MAKE) $(strip $(2))-install-sof
+	$(MAKE) $(strip $(2))-install-core-rbf
+
+# base .sof file rule — if missing, run generate-design then build; guarded so duplicate revision names don't cause warnings
+ifndef $(strip $(1))_$(strip $(3))_sof_rule_defined
+$(strip $(1))_$(strip $(3))_sof_rule_defined := 1
+
+$(strip $(1))/output_files/$(strip $(3)).sof: | $(strip $(1))/output_files
+	$(MAKE) $(strip $(2))-generate-design
+	$(MAKE) $(strip $(2))-package-design
+	$(MAKE) $(strip $(2))-prep
+	$(MAKE) $(strip $(2))-build
+endif
 
 endef
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is applicable to all designs.
   - Partial Reconfiguration
 
 ## Dependency
-* Altera Quartus Prime 26.1
+* Altera Quartus Prime 26.1.1
 * Supported Board
   - Altera Agilex 7 FPGA F-Series Transceiver-SoC Development Kit
   - Altera Agilex F-Series FPGA Development Kit

--- a/agilex_soc_devkit_ghrd/Makefile
+++ b/agilex_soc_devkit_ghrd/Makefile
@@ -147,7 +147,7 @@ ENABLE_NIOSV_SUBSYS ?= 0
 
 ####
 # Default Assignment (Do not modify)
-QUARTUS_DEVICE_FAMILY := Agilex
+QUARTUS_DEVICE_FAMILY := Agilex\ 7
 # Prelimenary Device
 #FM68 (cypress)
 #QUARTUS_DEVICE ?= AGFB014R17A2E2VR0
@@ -993,12 +993,6 @@ generate-agf023fa-soc-devkit-oobe-baseline:
 
 generate-agm039ea-soc-devkit-oobe-baseline:
 	make generate_from_tcl_internal QUARTUS_DEVICE=AGMF039R47A1E1VC BOARD_TYPE=devkit_fp82 CONFIG_SCHEME="AVST\ X8" BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=0 ENABLE_WATCHDOG_RST=0 OCM_DATAWIDTH=32 HBM_EN=1 HPS_F2S_IRQ_EN=0 HPS_STM_EN=0 HPS_EMIF_EN=0
-
-generate-fpga_first_revb_linear:
-	make generate_from_tcl_internal BOOTS_FIRST=fpga BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1
-
-generate-fpga_first_pr_linear:
-	make generate_from_tcl_internal BOOTS_FIRST=fpga BOARD_TYPE=DK-SI-AGF014E BOARD_PWRMGT=linear ENABLE_HPS_EMIF_ECC=1 ENABLE_PARTIAL_RECONFIGURATION=1
 
 ################################################
 

--- a/agilex_soc_devkit_ghrd/README.md
+++ b/agilex_soc_devkit_ghrd/README.md
@@ -94,16 +94,16 @@ make generate-agf023fa-soc-devkit-oobe-baseline
 ## GHRD Overview
 
 ### Hard Processor System (HPS)
-The GHRD HPS configuration matches the board schematic. Refer to [Agilex 7 Hard Processor System Technical Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683567/current) and [Agilex 7 Hard Processor System Component Reference Manual](https://www.intel.com/content/www/us/en/docs/programmable/683581/current) for more information on HPS configuration.
+The GHRD HPS configuration matches the board schematic. Refer to [Agilex 7 Hard Processor System Technical Reference Manual](https://docs.altera.com/r/docs/683567/current) and [Agilex 7 Hard Processor System Component Reference Manual](https://docs.altera.com/r/docs/683581/current) for more information on HPS configuration.
 
 ### HPS External Memory Interfaces (EMIF)
 The GHRD HPS EMIF configuration matches the board schematic. Refer to
-[External Memory Interfaces Agilex 7 F-Series and I-Series FPGA IP User Guide](https://www.intel.com/content/www/us/en/docs/programmable/683216/current) for more information on HPS EMIF configuration.
+[External Memory Interfaces Agilex 7 F-Series and I-Series FPGA IP User Guide](https://docs.altera.com/r/docs/683216/current) for more information on HPS EMIF configuration.
 
 ### HPS-to-FPGA Address Map for all designs
 The MPU region provide windows of 4 GB into the FPGA slave address space. The lower 1.5 GB of this space is mapped to two separate addresses - firstly from 0x8000_0000 to 0xDFFF_FFFF and secondly from 0x20_0000_0000 to 0x20_5FFF_FFFF. The following table lists the offset of each peripheral from the HPS-to-FPGA bridge in the FPGA portion of the SoC.
 
-Refer to [Agilex 7 Hard Processor System Address Map and Register Definitions](https://www.intel.com/content/www/us/en/programmable/hps/agilex7/hps.html) for details.
+Refer to [Agilex 7 Hard Processor System Address Map and Register Definitions](https://docs.altera.com/v/u/resources/747593/agilextm-7-fpga-hard-processor-system-hps-address-map-and-definitions-register-map) for details.
 
 | Peripheral | Address Offset | Size (bytes) | Attribute |
 | :-- | :-- | :-- | :-- |
@@ -149,10 +149,10 @@ An alternate revision of the project (persona 1) contains the following in the P
 ### JTAG master interfaces
 The GHRD JTAG master interfaces allows you to access peripherals in the FPGA with System Console, through the JTAG master module. This access does not rely on HPS software drivers.
 
-Refer to this [Guide](https://www.intel.com/content/www/us/en/docs/programmable/683819/current/analyzing-and-debugging-designs-with-84752.html) for information about system console.
+Refer to this [Guide](https://docs.altera.com/r/docs/683819/26.1/quartus-prime-pro-edition-user-guide-debug-tools/analyzing-and-debugging-designs-with-system-console) for information about system console.
 
 ### Interrupt Num
-The Interrupt Num in this readme are FPGA IRQ. They have offset of 17 when mapped to Generic Interrupt Controller (GIC) in device tree structure(dts). Refer to F2H FPGA Interrupt[0] in [GIC Interrupt Map for the SoC HPS](intel.com/content/www/us/en/docs/programmable/683567/24-3/hard-processor-system-technical-reference.html).
+The Interrupt Num in this readme are FPGA IRQ. They have offset of 17 when mapped to Generic Interrupt Controller (GIC) in device tree structure(dts). Refer to F2H FPGA Interrupt[0] in [GIC Interrupt Map for the SoC HPS](https://docs.altera.com/r/docs/683567/25.3.1/agilextm-7-hard-processor-system-technical-reference-manual/gic-interrupt-map-for-the-soc-hps).
 Number 49 is shown for F2H FPGA Interrupt[0] as the first 32 IRQ is reserved. (49 - 32 = 17).
 
 ## Binaries location

--- a/agilex_soc_devkit_ghrd/construct_subsys_sgmii.tcl
+++ b/agilex_soc_devkit_ghrd/construct_subsys_sgmii.tcl
@@ -81,17 +81,17 @@ connect "sgmii_csr_clk.out_clk          sgmii_rst_in.clk
          sgmii_csr_clk.out_clk          gmii_sgmii_adapter_0.peri_clock
          sgmii_rst_in.out_reset         gmii_sgmii_adapter_0.peri_reset
          emac_splitter_0.hps_gmii       gmii_sgmii_adapter_0.hps_gmii
-         gmii_sgmii_adapter_0.pcs_transmit_reset    eth_tse_0.pcs_transmit_reset_connection
-         gmii_sgmii_adapter_0.pcs_receive_reset     eth_tse_0.pcs_receive_reset_connection
-         eth_tse_0.pcs_transmit_clock_connection    gmii_sgmii_adapter_0.pcs_transmit_clock
-         eth_tse_0.pcs_receive_clock_connection     gmii_sgmii_adapter_0.pcs_receive_clock
+         gmii_sgmii_adapter_0.pcs_transmit_reset    eth_tse_0.reset_tx_clk
+         gmii_sgmii_adapter_0.pcs_receive_reset     eth_tse_0.reset_rx_clk
+         eth_tse_0.tx_clk    gmii_sgmii_adapter_0.pcs_transmit_clock
+         eth_tse_0.rx_clk     gmii_sgmii_adapter_0.pcs_receive_clock
          gmii_sgmii_adapter_0.pcs_clock_enable      eth_tse_0.clock_enable_connection
          gmii_sgmii_adapter_0.pcs_gmii              eth_tse_0.gmii_connection
          gmii_sgmii_adapter_0.pcs_mii               eth_tse_0.mii_connection
          
-         sgmii_clk_125.out_clk          eth_tse_0.pcs_ref_clk_clock_connection
-         sgmii_csr_clk.out_clk          eth_tse_0.control_port_clock_connection
-         sgmii_rst_in.out_reset         eth_tse_0.reset_connection
+         sgmii_clk_125.out_clk          eth_tse_0.ref_clk
+         sgmii_csr_clk.out_clk          eth_tse_0.clk
+         sgmii_rst_in.out_reset         eth_tse_0.reset
          
          sgmii_csr_clk.out_clk          sgmii_debug_status_pio.clk
          sgmii_rst_in.out_reset         sgmii_debug_status_pio.reset
@@ -119,7 +119,7 @@ export emac_splitter_0 ptp             ptp
 
 export eth_tse_0       sgmii_status_connection      sgmii_status
 export eth_tse_0       status_led_connection        status_led
-export eth_tse_0       serdes_control_connection    serdes_control
+export eth_tse_0       rx_recovclkout               serdes_control
 export eth_tse_0       lvds_tx_pll_locked           lvds_tx_pll_locked
 export eth_tse_0       serial_connection            serial_connection
 export sgmii_debug_status_pio   external_connection     sgmii_debug_status_pio

--- a/agilex_soc_devkit_ghrd/design_config.tcl
+++ b/agilex_soc_devkit_ghrd/design_config.tcl
@@ -15,7 +15,7 @@
 set QSYS_NAME qsys_top
 set PROJECT_NAME ghrd_agilex
 set TOP_NAME ghrd_agilex_top
-set DEVICE_FAMILY "Agilex"
+set DEVICE_FAMILY "Agilex 7"
 set DEVICE AGFB014R24A3E3VR0
 
 ##### features of GHRD enabling #####

--- a/agilex_soc_devkit_ghrd/intel_custom_ip/license.txt
+++ b/agilex_soc_devkit_ghrd/intel_custom_ip/license.txt
@@ -1,10 +1,7 @@
 ================================================================================
-The IPs supported in this released folder "intel_custom_ip" is Licensed 
-for use under the Intel Quartus Prime and Intel FPGA IP License Agreement 
+The IPs supported in this released folder "intel_custom_ip" is Licensed
+for use under the Intel Quartus Prime and Intel FPGA IP License Agreement
 unless otherwise specified in the file header. 
-
-Refer to http://fpgasoftware.intel.com/eula for more information about 
-Intel Quartus Prime and Intel FPGA IP License Agreement.
 ================================================================================
 
 QUARTUS PRIME AND INTEL FPGA IP LICENSE AGREEMENT, VERSION 20.3


### PR DESCRIPTION
## Release Information:
Quartus Version: 26.1.1 Build 130 08/06/2026 SC Pro Edition
Tag: QPDS26.1.1_REL_GSRD_PR
Build: socfpga_ghrd_fm_base/26.1.1/863

## New Features and Enhancements
- Added build flow to generate ghrd.core.rbf from .sof via quartus_pfg (hps=ON, hps_core_only=ON) and install it under install/designs. Full *-all targets now produce zip, sof, and core rbf.
- Default device family parameter updated from Agilex to Agilex 7 in Makefile / design_config.tcl.

## Issues Resolved
- The SGMII reference design achieved over 900 Mbps throughput after optimizing the test packet size.

Example: normal packet
```
iperf3 -c 192.168.2.10
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.01  sec  1002 MBytes   839 Mbits/sec    0            sender
[  5]   0.00-10.01  sec   999 MBytes   837 Mbits/sec                  receiver
```
Example: optimized packet
```
iperf3 -c 192.168.2.10 -w 4M -l 1470
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  1.10 GBytes   942 Mbits/sec    0            sender
[  5]   0.00-10.00  sec  1.10 GBytes   941 Mbits/sec                  receiver

```
## Latest Known Issues
None

## IP Upgrade Notes
- Triple-Speed Ethernet (TSE) IP port renames for Quartus 26.1.1 in SGMII reference design is not backwards compatible. e.g. pcs_*_connection → tx_clk / rx_clk / reset_tx_clk / reset_rx_clk / ref_clk / clk / reset, and serdes_control_connection → rx_recovclkout.
- Auto-Upgrade / HPS EMIF *_DLR parameters (carry-forward risk)
  - Board EMIF TCL still contains JEDEC *_DLR parameters (e.g. MEM_DDR4_TFAW_DLR_CYC, MEM_DDR4_TRFC_DLR_NS). Upgrading HPS-EMIF IP across Quartus releases may still require manual removal of *_DLR entries to avoid auto-upgrade failures.
  - Resolution reference: [Altera KB – automatic upgrade failure](https://community.altera.com/kb/knowledge-base/why-does-the-automatic-upgrade-mechanism-in-the-quartus%C2%AE-prime-software-fails-fo/340413)